### PR TITLE
Подключение BetterFeed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,7 @@
  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', 'UA-62517081-1', 'auto');
   </script>
+  <script src="https://cdn.rawgit.com/davidmz/BetterFeed/v1.13.6/build/better-feed.site.js" type="text/javascript" charset="utf-8" async id="betterfeed-script"></script>
   <noscript>
     <style>
       .jsonly { display: none }


### PR DESCRIPTION
Добавляет в настройки галочку «включить BetterFeed», выключенную по умолчанию:

![2015-06-15 11-47-30 freefeed - google chrome](https://cloud.githubusercontent.com/assets/132120/8156303/6dbbff7e-1354-11e5-895f-24c8f8af1133.png)

Скрипт BetterFeed подключается только если юзер включил эту галочку.
