### PR TITLE
Comments disabled (Ember client)

### DIFF
--- a/public/js/app/controllers/PostGenericController.js
+++ b/public/js/app/controllers/PostGenericController.js
@@ -58,6 +58,13 @@ define(["config",
       return likes.get('length') + this.get('model.omittedLikes') - 3
     }.property('model.omittedLikes', 'model.likes', 'model.likes.length'),
 
+    canAddComment: function() {
+      var commentsDisabled = this.get('model.commentsDisabled')
+      var postAuthor = this.get('model.createdBy.id')
+      var currentUser = this.get('session.currentUser.id')
+      return (!commentsDisabled || (postAuthor === currentUser))
+    }.property('model.commentsDisabled', 'model.createdBy.id', 'session.currentUser.id'),
+
     isEdit: false,
     isFormVisible: false,
     isSendingComment: false,

--- a/public/js/app/models/Post.js
+++ b/public/js/app/models/Post.js
@@ -20,6 +20,7 @@ define(["config",
     groups: DS.hasMany('group'),
     postedTo: DS.hasMany('subscription'),
 
+    commentsDisabled: DS.attr('boolean'),
     isHidden: DS.attr('boolean'),
 
     timeline: DS.belongsTo('timeline'),

--- a/public/js/app/templates/postTemplate.handlebars
+++ b/public/js/app/templates/postTemplate.handlebars
@@ -92,7 +92,17 @@
       <span class="post-controls">
         {{#if controller.session.signedIn}}
           -
-          <a {{action 'focusCommentForm' target=view}} class="p-post-comment">Comment</a>
+          {{#if model.commentsDisabled}}
+            {{#if view.isOwner}}
+              <i>Comments disabled (not for you)</i>
+              -
+              <a {{action 'focusCommentForm' target=view}} class="p-post-comment">Comment</a>
+            {{else}}
+              <i>Comments disabled</i>
+            {{/if}}
+          {{else}}
+            <a {{action 'focusCommentForm' target=view}} class="p-post-comment">Comment</a>
+          {{/if}}
           -
           {{#if isLiked}}
             <span><a {{action 'unlike'}} class="p-post-unlike">Un-like</a></span>

--- a/public/js/app/templates/postTemplate.handlebars
+++ b/public/js/app/templates/postTemplate.handlebars
@@ -133,25 +133,27 @@
         {{view "post-comment" content=comment}}
       {{/each}}
 
-      {{#if controller.session.signedIn}}
-        <div class="comment p-timeline-comment">
-          <a class="date">
-            <i class="fa fa-comment-o icon"></i>
-          </a>
-          <div class="body">
-            <div class="edit p-timeline-edit-comment">
-              <div class="p-timeline-comment-create">
-                {{view 'create-comment'}}
-              </div>
-              <div class="p-timeline-comment-actions">
-                <button {{action 'create'}} class="btn btn-default btn-xs p-timeline-comment-post">Comment</button>
-                {{#if controller.isSendingComment}}
-                  <span class="throbber"><img src="/img/throbber-16.gif" width="16" height="16" /></span>
-                {{/if}}
+      {{#if controller.canAddComment}}
+        {{#if controller.session.signedIn}}
+          <div class="comment p-timeline-comment">
+            <a class="date">
+              <i class="fa fa-comment-o icon"></i>
+            </a>
+            <div class="body">
+              <div class="edit p-timeline-edit-comment">
+                <div class="p-timeline-comment-create">
+                  {{view 'create-comment'}}
+                </div>
+                <div class="p-timeline-comment-actions">
+                  <button {{action 'create'}} class="btn btn-default btn-xs p-timeline-comment-post">Comment</button>
+                  {{#if controller.isSendingComment}}
+                    <span class="throbber"><img src="/img/throbber-16.gif" width="16" height="16" /></span>
+                  {{/if}}
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        {{/if}}
       {{/if}}
     </div>
   </div>

--- a/public/js/app/templates/timelinePostTemplate.handlebars
+++ b/public/js/app/templates/timelinePostTemplate.handlebars
@@ -72,7 +72,17 @@
       <span class="post-controls">
         {{#if controller.session.signedIn}}
           -
-          <a {{action 'toggleCommentForm'}} class="p-timeline-post-comment-action">Comment</a>
+          {{#if post.model.commentsDisabled}}
+            {{#if view.isOwner}}
+              <i>Comments disabled (not for you)</i>
+              -
+              <a {{action 'toggleCommentForm'}} class="p-timeline-post-comment-action">Comment</a>
+            {{else}}
+              <i>Comments disabled</i>
+            {{/if}}
+          {{else}}
+            <a {{action 'toggleCommentForm'}} class="p-timeline-post-comment-action">Comment</a>
+          {{/if}}
           -
           {{#if controller.isLiked}}
             <span><a {{action 'unlike'}} class="p-timeline-post-unlike-action">Un-like</a></span>

--- a/public/js/app/templates/timelinePostTemplate.handlebars
+++ b/public/js/app/templates/timelinePostTemplate.handlebars
@@ -159,19 +159,21 @@
           </div>
         </div>
       {{else}}
-        {{#if post.comments.length}}
-          {{#unless controller.hasOmittedComments}}
-            {{#if controller.session.signedIn}}
-              <div class="add-comment-block">
-                <a class="fa-stack fa-1x" {{action 'toggleCommentForm'}}>
-                  <i class="fa fa-comment-o fa-stack-1x"></i>
-                  <i class="fa fa-square fa-inverse fa-stack-1x"></i>
-                  <i class="fa fa-plus fa-stack-1x"></i>
-                </a>
-                <a class="add-comment-link" {{action 'toggleCommentForm'}}>Add comment</a>
-              </div>
-            {{/if}}
-          {{/unless}}
+        {{#if controller.canAddComment}}
+          {{#if post.comments.length}}
+            {{#unless controller.hasOmittedComments}}
+              {{#if controller.session.signedIn}}
+                <div class="add-comment-block">
+                  <a class="fa-stack fa-1x" {{action 'toggleCommentForm'}}>
+                    <i class="fa fa-comment-o fa-stack-1x"></i>
+                    <i class="fa fa-square fa-inverse fa-stack-1x"></i>
+                    <i class="fa fa-plus fa-stack-1x"></i>
+                  </a>
+                  <a class="add-comment-link" {{action 'toggleCommentForm'}}>Add comment</a>
+                </div>
+              {{/if}}
+            {{/unless}}
+          {{/if}}
         {{/if}}
       {{/if}}
     </div>


### PR DESCRIPTION
Partial support:
- Added "Comments disabled" remarks for those special posts
- Hid forms for commenting the posts with "Comments disabled"
- But there's no controls for disabling comments for user's own posts

See also:
- https://github.com/FreeFeed/freefeed-server/pull/27 — full support for the server. 
- https://github.com/FreeFeed/freefeed-react-client/pull/162 — full support for official React client (check it out, there are lots of screenshots).
